### PR TITLE
Removendo a necessidade de valor e usando o atributo \SensitiveParameter 

### DIFF
--- a/src/Validator/Constraints/Documento.php
+++ b/src/Validator/Constraints/Documento.php
@@ -13,7 +13,7 @@ class Documento extends Constraint
     public string $messageCnpj = 'O documento informado não é um CNPJ válido';
     public string $messageCpf = 'O documento informado não é um CPF válido';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return static::class . 'Validator';
     }

--- a/src/Validator/Constraints/DocumentoValidator.php
+++ b/src/Validator/Constraints/DocumentoValidator.php
@@ -10,10 +10,12 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class DocumentoValidator extends ConstraintValidator
 {
-    public function validate(mixed $value, Constraint $constraint)
-    {
-        if (null === $value) {
-            $this->context->buildViolation($constraint->messageSize)->addViolation();
+    public function validate(
+        #[\SensitiveParameter]
+        mixed $value,
+        Constraint $constraint
+    ) {
+        if (null === $value || '' === $value) {
             return;
         }
 
@@ -23,22 +25,24 @@ class DocumentoValidator extends ConstraintValidator
 
         $value = preg_replace('/[^0-9]/', '', (string) $value);
 
-        if (strlen((string) $value) !== 11 && strlen((string) $value) !== 14 && isset($constraint->messageSize)) {
+        if (strlen($value) !== 11 && strlen($value) !== 14 && isset($constraint->messageSize)) {
             $this->context->buildViolation($constraint->messageSize)->addViolation();
         }
 
-        if (strlen((string) $value) === 14 && !$this->validateCnpj($value)) {
+        if (strlen($value) === 14 && !$this->validateCnpj($value)) {
             $this->context->buildViolation($constraint->messageCnpj)->addViolation();
         }
 
-        if (strlen((string) $value) === 11 && !$this->validateCpf($value)) {
+        if (strlen($value) === 11 && !$this->validateCpf($value)) {
             $this->context->buildViolation($constraint->messageCpf)->addViolation();
         }
     }
 
     // code from Respect\Validation
-    private function validateCnpj($input): bool
-    {
+    private function validateCnpj(
+        #[\SensitiveParameter]
+        string $input
+    ): bool {
         if (!is_scalar($input)) {
             return false;
         }
@@ -85,8 +89,10 @@ class DocumentoValidator extends ConstraintValidator
     }
 
     // code from Respect\Validation
-    private function validateCpf($input): bool
-    {
+    private function validateCpf(
+        #[\SensitiveParameter]
+        string $input
+    ): bool {
         // Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);
 

--- a/tests/Validator/Constraints/DocumentoValidatorTest.php
+++ b/tests/Validator/Constraints/DocumentoValidatorTest.php
@@ -36,51 +36,83 @@ class DocumentoValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    public function testNullIsInvalid()
+    public function testNullIsValid()
     {
         $this->validator->validate(null, new Documento());
 
-        $this->buildViolation('O documento informado precisa ter 11 ou 14 caracteres')
-            ->assertRaised();
+        $this->assertNoViolation();
     }
 
     public function testEmptyStringIsInvalid()
     {
         $this->validator->validate('', new Documento());
 
-        $this->buildViolation('O documento informado precisa ter 11 ou 14 caracteres')
-            ->assertRaised();
+        $this->assertNoViolation();
     }
 
     public function testArbitraryStringIsInvalid()
     {
-        $this->validator->validate('a', new Documento());
+        $documento = new Documento();
+        $this->validator->validate('a', $documento);
 
-        $this->buildViolation('O documento informado precisa ter 11 ou 14 caracteres')
+        $this->buildViolation($documento->messageSize)
             ->assertRaised();
     }
 
     public function testArbitraryIntegerIsInvalid()
     {
-        $this->validator->validate(123, new Documento());
+        $documento = new Documento();
+        $this->validator->validate(123, $documento);
 
-        $this->buildViolation('O documento informado precisa ter 11 ou 14 caracteres')
+        $this->buildViolation($documento->messageSize)
             ->assertRaised();
     }
 
     public function testWrongCpfIsInvalid()
     {
-        $this->validator->validate('07277482031', new Documento());
+        $documento = new Documento();
+        $this->validator->validate('07277482031', $documento);
 
-        $this->buildViolation('O documento informado não é um CPF válido')
+        $this->buildViolation($documento->messageCpf)
             ->assertRaised();
     }
 
     public function testWrongCnpjIsInvalid()
     {
-        $this->validator->validate('11.885.649/0001-54', new Documento());
+        $documento = new Documento();
+        $this->validator->validate('11.885.649/0001-54', $documento);
 
-        $this->buildViolation('O documento informado não é um CNPJ válido')
+        $this->buildViolation($documento->messageCnpj)
+            ->assertRaised();
+    }
+
+    public function testSizeMessageCanBeCustomized()
+    {
+        $documento = new Documento();
+        $documento->messageSize = 'myMessageSize';
+        $this->validator->validate('a', $documento);
+
+        $this->buildViolation('myMessageSize')
+            ->assertRaised();
+    }
+
+    public function testCpfMessageCanBeCustomized()
+    {
+        $documento = new Documento();
+        $documento->messageCpf = 'myMessageCpf';
+        $this->validator->validate('07277482031', $documento);
+
+        $this->buildViolation('myMessageCpf')
+            ->assertRaised();
+    }
+
+    public function testCnpjMessageCanBeCustomized()
+    {
+        $documento = new Documento();
+        $documento->messageCnpj = 'myMessageCnpj';
+        $this->validator->validate('11.885.649/0001-54', $documento);
+
+        $this->buildViolation('myMessageCnpj')
             ->assertRaised();
     }
 }

--- a/tests/Validator/Constraints/DocumentoValidatorTest.php
+++ b/tests/Validator/Constraints/DocumentoValidatorTest.php
@@ -43,7 +43,7 @@ class DocumentoValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testEmptyStringIsInvalid()
+    public function testEmptyStringIsValid()
     {
         $this->validator->validate('', new Documento());
 


### PR DESCRIPTION
Olá,

Fiz as seguintes mudanças no seu código:
1 - Remoção da necessidade do valor validado ter um valor setado
Motivo: O symfony já tem um NotNull e NotBlank Validators que pode ser usado para essa checagem, e posso ter um caso onde o documento é opcional, mas se existir, precisa ser válido
2 - Utilizando o atributo \SensitiveParamter do PHP 8.2
Movito: Evitar que números de CPNJ e CPF entrem em LOG, criando uma segurança de informação por conta da LGPD.